### PR TITLE
Fix Nuxt deployment error by converting config to CommonJS syntax

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   ssr: true,
   /*
    ** Headers of the page


### PR DESCRIPTION
The esm package used by Nuxt 2 to handle ES module syntax (export default) is incompatible with Node.js 16+, causing:
  TypeError: Function.prototype.apply was called on undefined

Switching to module.exports bypasses the esm loader and resolves the error.

https://claude.ai/code/session_012tmE1gxgwWKwnWQRNXWahq